### PR TITLE
Make SDLx::Music match the docs

### DIFF
--- a/lib/SDLx/Music.pm
+++ b/lib/SDLx/Music.pm
@@ -45,7 +45,8 @@ sub new {
 
 sub data {
     my $self = shift;
-    return if $#_ < 0;
+    
+    return $self->{data} if $#_ == -1;
     return $self->{data}->{ $_[0] } if $#_ == 0;
 
     my %data = @_;
@@ -92,7 +93,11 @@ sub play {
     my %override  = @_;
 
     return unless defined $play_data;
-
+    
+    if ( ref $play_data eq '') {
+        $play_data = $self->{data}->{$play_data};
+    }
+    
     my $volume  = $play_data->{volume}  || $override{volume}  || 50;
     my $fade_in = $play_data->{fade_in} || $override{fade_in} || 0;
     my $loops   = $play_data->{loops}   || $override{loops}   || 1;


### PR DESCRIPTION
Make SDLx::Music match the docs:
- data returns hashref with no args,
- play can be called with 'name'
