### PR TITLE
clarify argments to handler subs in SDLx::App

### DIFF
--- a/lib/pods/SDLx/App.pod
+++ b/lib/pods/SDLx/App.pod
@@ -162,13 +162,19 @@ C<SDLx::App> is a C<SDLx::Controller>. Use the event, show and handlers to run t
 
   my $app = SDLx::App->new( width => 200, height => 200);
 
-  $app->add_event_handler( sub{ return 0 if $_[0]->type == SDL_QUIT; return 1});
+  $app->add_event_handler( sub{
+      my ($event, $app) = @_;
+      return $_[0]->type == SDL_QUIT ? 0 : 1;
+  });
 
-  $app->add_show_handler( sub{ $app->update() } );
+  $app->add_show_handler( sub{
+      my ($delta, $app) = @_;
+      $app->update;
+  } );
 
-  $app->add_move_handler( 
-  sub{ 
-  #calc your physics here 
+  $app->add_move_handler( sub{ 
+      my ($step, $app, $t) = @_;
+      #calc your physics here 
   } );
 
   $app->run();


### PR DESCRIPTION
Previously it was easy for someone to look at the docs and assume the move handler operated in fixed steps, only discovering how wrong that is if they end up with a need to dig into the SDLx::Controller documentation. With this change it becomes obvious that the move handler takes a number of arguments and that research is necessary.

And while i'm at it, also adding the arguments for the other handlers.