### PR TITLE
remove apparently unnecessary pump_events to smooth out performance profile

### DIFF
--- a/lib/SDLx/Controller.pm
+++ b/lib/SDLx/Controller.pm
@@ -147,7 +147,6 @@ sub pause {
 
 sub _event {
 	my ($self, $ref) = @_;
-	SDL::Events::pump_events();
 	while ( SDL::Events::poll_event( $_event{ $ref} ) ) {
 		$self->_exit_on_quit( $_event{ $ref}  ) if $_eoq{$ref};
 		foreach my $event_handler ( @{ $_event_handlers{ $ref} } ) {


### PR DESCRIPTION
Note ahead, in the following comment @kthakore observed issues around pump_events that i do not understand fully, and i would love if he could find the time to provide input on this:

SHA-1: 4aa0251049879b65b9466ad638d32960967c5cf6

* Need to pump before we poll to prevent skipping too many events before processing something

That said, according to the documentation:

http://sdl.beuc.net/sdl.wiki/SDL_PumpEvents

> Often the need for calls to SDL_PumpEvents is hidden from the user
> since SDL_PollEvent [...] implicitly call SDL_PumpEvents.
> [...] if you are not polling or waiting for events [...]
> you must call SDL_PumpEvents

http://sdl.beuc.net/sdl.wiki/SDL_PollEvent

> this function implicitly calls SDL_PumpEvents

This means that removing it should have no deleterious effects.

At the same time, its presence does seem to cause some. In the graph in this screenshot you will notice occasional red spikes at the bottom. These are caused by pump_events taking more time than ordinary, and disappear with (on Win7) no noticable side effects when pump_events is removed.

Given that clear benefit, i would like to see this commit released live in a production release to see if it causes ill effects for anyone using SDL.

![screenshot 2015-03-13 15 12 35](https://cloud.githubusercontent.com/assets/175467/6685920/7f430910-cc9e-11e4-8630-f3ae24287982.png)
