### PR TITLE
tests: remove old (and wrong) Hurd workaround

### DIFF
--- a/t/core_cd.t
+++ b/t/core_cd.t
@@ -9,9 +9,6 @@ BEGIN {
 	use SDL::TestTool;
 	use Config;
 
-	plan( skip_all => 'GNU Hurd <= 0.3 not supported' )
-		if $^O eq 'gnu' && $Config{osvers} <= 0.3;
-
 	plan( skip_all => 'Failed to init cdrom' )
 		unless SDL::TestTool->init(SDL_INIT_CDROM);
 }


### PR DESCRIPTION
Other than being no more applicable with recent Hurd versions (e.g. 0.5, 0.6), it was working around a bug in `TestTool::init`, not properly handling failures in `SDL::init`.

Basically it reverts commit 4931c49d1dfdc11aaf86d85db734104a37bef538.
