### PR TITLE
Fix implicit declaration of _calc_offset

### DIFF
--- a/src/SDLx/Surface.xs
+++ b/src/SDLx/Surface.xs
@@ -16,6 +16,14 @@
 #include <SDL_gfxPrimitives.h>
 #endif
 
+int _calc_offset ( SDL_Surface* surface, int x, int y )
+{
+    int offset;
+    offset  = (surface->pitch * y) / surface->format->BytesPerPixel;
+    offset += x;
+    return offset;
+}
+
 SV * get_pixel32 (SDL_Surface *surface, int x, int y)
 {
     /* Convert the pixels to 32 bit  */
@@ -50,14 +58,6 @@ SV * construct_p_matrix ( SDL_Surface *surface )
     }
 
     return newRV_noinc((SV *)matrix);
-}
-
-int _calc_offset ( SDL_Surface* surface, int x, int y )
-{
-    int offset;
-    offset  = (surface->pitch * y) / surface->format->BytesPerPixel;
-    offset += x;
-    return offset;
 }
 
 unsigned int _get_pixel(SDL_Surface * surface, int offset)


### PR DESCRIPTION
Fixes:

```
lib/SDLx/Surface.xs:25:25: error: implicit declaration of function '_calc_offset' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    void* s =  pixels + _calc_offset(surface, x, y); 
                        ^
```