### PR TITLE
Adapt to perl 5.37.1

### DIFF
--- a/src/SDLx/Controller/Interface.xs
+++ b/src/SDLx/Controller/Interface.xs
@@ -57,15 +57,15 @@ void evaluate(SDLx_Interface *obj, SDLx_Derivative *out, SDLx_State *initial, fl
 
 	SV *temp;
 	temp           = av_pop(accel);
-	out->dv_x      = sv_nv(temp);
+	out->dv_x      = SvNVx(temp);
 	SvREFCNT_dec(temp);
 
 	temp           = av_pop(accel);
-	out->dv_y      = sv_nv(temp);
+	out->dv_y      = SvNVx(temp);
 	SvREFCNT_dec(temp);
 
 	temp           = av_pop(accel);
-	out->dang_v    = sv_nv(temp);
+	out->dang_v    = SvNVx(temp);
 	SvREFCNT_dec(temp);
 
 	SvREFCNT_dec((SV *)accel);
@@ -90,15 +90,15 @@ void evaluate_dt(SDLx_Interface *obj, SDLx_Derivative *out, SDLx_State *initial,
 
 	SV *temp;
 	temp           = av_pop(accel);
-	out->dv_x      = sv_nv(temp);
+	out->dv_x      = SvNVx(temp);
 	SvREFCNT_dec(temp);
 
 	temp           = av_pop(accel);
-	out->dv_y      = sv_nv(temp);
+	out->dv_y      = SvNVx(temp);
 	SvREFCNT_dec(temp);
 
 	temp           = av_pop(accel);
-	out->dang_v    = sv_nv(temp);
+	out->dang_v    = SvNVx(temp);
 	SvREFCNT_dec(temp);
 
 	SvREFCNT_dec((SV *)accel);


### PR DESCRIPTION
Perl 5.37.1 removed a deprecated sv_nv() macro and SDL fails to build with Perl 5.38.0:

~~~~
lib/SDLx/Controller/Interface.xs:60:26: error: implicit declaration of function 'sv_nv'
   60 |         out->dv_x      = sv_nv(temp);
      |                          ^~~~~
~~~~

Users are advised to use SvNVx() macro instead. SvNVx() seems to have been available all the time (it predates a commit from 1993-10-07).

This patch does that.

https://github.com/PerlGameDev/SDL/issues/303